### PR TITLE
fix FastCGI closing session

### DIFF
--- a/agi/agi_bin.go
+++ b/agi/agi_bin.go
@@ -43,7 +43,7 @@ func LoadConfEnv() ConfEnv {
 
 func Run(handler HandlerFunc) {
 	ctx := context.Background()
-	session, err := NewSession(ctx, os.Stdin, os.Stdout)
+	session, err := NewSession(ctx, os.Stdin, os.Stdout, nil)
 	if err != nil {
 		zap.S().With("err", err).Error("init session failed")
 		os.Exit(1)


### PR DESCRIPTION
In case of using FastCGI, the session wasn't closed, because `Session.conn` attribute wasn't assigned. Now it is. The implementation also closes the session implicitly.

```go
package main

import (
	"github.com/wenerme/astgo/agi"
)

func main() {
	agi.Listen("", func(session *agi.Session) {
		client := session.Client()
		client.Answer()
		client.StreamFile("activated", "#")
		client.SetVariable("AGISTATUS", "SUCCESS")
		client.Hangup()
	})
}
```